### PR TITLE
fix: recover from tool_use_failed errors instead of fatally aborting

### DIFF
--- a/internal/openai/chat.go
+++ b/internal/openai/chat.go
@@ -97,7 +97,7 @@ func isToolCallParsingError(err error) bool {
 	msg := err.Error()
 	return strings.Contains(msg, "tool_use_failed") ||
 		strings.Contains(msg, "Failed to parse tool call arguments") ||
-		strings.Contains(msg, "invalid_request_error") && strings.Contains(msg, "tool")
+		strings.Contains(msg, "invalid_request_error") && strings.Contains(msg, "tool") && strings.Contains(strings.ToLower(msg), "parse")
 }
 
 // extractFailedGeneration attempts to extract the failed_generation field from a
@@ -129,6 +129,7 @@ func (o *OpenAI) CreateChat(messages *models.AIChatHistory, enableTools bool, us
 	ctx, cancel := o.requestContext()
 	defer cancel()
 	params := o.buildParams(*messages, enableTools)
+	var lastParsingErr error
 
 	for range o.toolPassLimit() {
 		if o.RequestGate != nil {
@@ -139,8 +140,9 @@ func (o *OpenAI) CreateChat(messages *models.AIChatHistory, enableTools bool, us
 		chatCompletion, err := o.Client.Chat.Completions.New(ctx, params)
 		if err != nil {
 			if isToolCallParsingError(err) {
-				log.Printf("[karma] Tool call parsing error, retrying: %v", err)
 				failedGen := extractFailedGeneration(err)
+				log.Printf("[karma] Tool call parsing error, retrying (has_failed_gen=%v)", failedGen != "")
+				lastParsingErr = err
 				correctionMsg := "Your previous tool call had malformed JSON arguments and could not be parsed. " +
 					"Please call the tool again with properly escaped JSON. " +
 					"Make sure all string values are properly escaped (no unescaped newlines, quotes, or special characters in JSON strings). " +
@@ -258,6 +260,9 @@ func (o *OpenAI) CreateChat(messages *models.AIChatHistory, enableTools bool, us
 			})
 		}
 	}
+	if lastParsingErr != nil {
+		return nil, fmt.Errorf("exceeded tool execution passes: tool call parsing failed: %w", lastParsingErr)
+	}
 	return nil, fmt.Errorf("exceeded tool execution passes")
 }
 
@@ -265,6 +270,7 @@ func (o *OpenAI) CreateChatStream(messages *models.AIChatHistory, chunkHandler f
 	ctx, cancel := o.requestContext()
 	defer cancel()
 	params := o.buildParams(*messages, enableTools)
+	var lastParsingErr error
 
 	for range o.toolPassLimit() {
 		if o.RequestGate != nil {
@@ -275,8 +281,9 @@ func (o *OpenAI) CreateChatStream(messages *models.AIChatHistory, chunkHandler f
 		acc, err := o.streamAndAccumulate(ctx, params, chunkHandler)
 		if err != nil {
 			if isToolCallParsingError(err) && acc != nil {
-				log.Printf("[karma] Tool call parsing error during streaming, retrying: %v", err)
 				failedGen := extractFailedGeneration(err)
+				log.Printf("[karma] Tool call parsing error during streaming, retrying (has_failed_gen=%v)", failedGen != "")
+				lastParsingErr = err
 				correctionMsg := "Your previous tool call had malformed JSON arguments and could not be parsed. " +
 					"Please call the tool again with properly escaped JSON. " +
 					"Make sure all string values are properly escaped (no unescaped newlines, quotes, or special characters in JSON strings). " +
@@ -396,6 +403,9 @@ func (o *OpenAI) CreateChatStream(messages *models.AIChatHistory, chunkHandler f
 				UniqueId:   utils.GenerateID(16),
 			})
 		}
+	}
+	if lastParsingErr != nil {
+		return nil, fmt.Errorf("exceeded tool execution passes: tool call parsing failed: %w", lastParsingErr)
 	}
 	return nil, fmt.Errorf("exceeded tool execution passes")
 }

--- a/internal/openai/chat.go
+++ b/internal/openai/chat.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
@@ -87,6 +88,43 @@ func (o *OpenAI) ApplyRequestTimeout() {
 	o.Client = createClientWithTimeout(o.RequestTimeout, opts...)
 }
 
+// isToolCallParsingError checks if an error is related to tool call argument parsing
+// failures from the API (e.g., Groq/OpenAI returning tool_use_failed).
+func isToolCallParsingError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "tool_use_failed") ||
+		strings.Contains(msg, "Failed to parse tool call arguments") ||
+		strings.Contains(msg, "invalid_request_error") && strings.Contains(msg, "tool")
+}
+
+// extractFailedGeneration attempts to extract the failed_generation field from a
+// tool_use_failed error so the model can be asked to fix it.
+func extractFailedGeneration(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := err.Error()
+	idx := strings.Index(msg, "failed_generation")
+	if idx == -1 {
+		return ""
+	}
+	// Try to extract JSON from the error
+	braceStart := strings.Index(msg, "{")
+	if braceStart == -1 {
+		return msg[idx:]
+	}
+	var errData map[string]any
+	if jsonErr := json.Unmarshal([]byte(msg[braceStart:]), &errData); jsonErr == nil {
+		if fg, ok := errData["failed_generation"].(string); ok {
+			return fg
+		}
+	}
+	return msg[idx:]
+}
+
 func (o *OpenAI) CreateChat(messages *models.AIChatHistory, enableTools bool, useMCPExecution bool) (*openai.ChatCompletion, error) {
 	ctx, cancel := o.requestContext()
 	defer cancel()
@@ -100,6 +138,19 @@ func (o *OpenAI) CreateChat(messages *models.AIChatHistory, enableTools bool, us
 		}
 		chatCompletion, err := o.Client.Chat.Completions.New(ctx, params)
 		if err != nil {
+			if isToolCallParsingError(err) {
+				log.Printf("[karma] Tool call parsing error, retrying: %v", err)
+				failedGen := extractFailedGeneration(err)
+				correctionMsg := "Your previous tool call had malformed JSON arguments and could not be parsed. " +
+					"Please call the tool again with properly escaped JSON. " +
+					"Make sure all string values are properly escaped (no unescaped newlines, quotes, or special characters in JSON strings). " +
+					"Use \\n for newlines within string values."
+				if failedGen != "" {
+					correctionMsg += "\nThe failed generation was: " + failedGen
+				}
+				params.Messages = append(params.Messages, openai.UserMessage(correctionMsg))
+				continue
+			}
 			return nil, err
 		}
 
@@ -223,6 +274,22 @@ func (o *OpenAI) CreateChatStream(messages *models.AIChatHistory, chunkHandler f
 		}
 		acc, err := o.streamAndAccumulate(ctx, params, chunkHandler)
 		if err != nil {
+			if isToolCallParsingError(err) && acc != nil {
+				log.Printf("[karma] Tool call parsing error during streaming, retrying: %v", err)
+				failedGen := extractFailedGeneration(err)
+				correctionMsg := "Your previous tool call had malformed JSON arguments and could not be parsed. " +
+					"Please call the tool again with properly escaped JSON. " +
+					"Make sure all string values are properly escaped (no unescaped newlines, quotes, or special characters in JSON strings). " +
+					"Use \\n for newlines within string values."
+				if failedGen != "" {
+					correctionMsg += "\nThe failed generation was: " + failedGen
+				}
+				if len(acc.Choices) > 0 && acc.Choices[0].Message.Content != "" {
+					params.Messages = append(params.Messages, openai.AssistantMessage(acc.Choices[0].Message.Content))
+				}
+				params.Messages = append(params.Messages, openai.UserMessage(correctionMsg))
+				continue
+			}
 			return nil, err
 		}
 

--- a/internal/openai/utils.go
+++ b/internal/openai/utils.go
@@ -293,7 +293,7 @@ func (o *OpenAI) streamAndAccumulate(ctx context.Context, params openai.ChatComp
 		}
 	}
 	if err := stream.Err(); err != nil {
-		return nil, err
+		return &acc, err
 	}
 	return &acc, nil
 }


### PR DESCRIPTION
## Summary
- **`streamAndAccumulate`** now returns accumulated data even on error, preventing loss of streamed content when API errors occur mid-stream
- **`CreateChat` and `CreateChatStream`** detect `tool_use_failed` / argument parsing errors from OpenAI-compatible APIs (Groq, etc.) and retry with a correction message instead of fatally aborting
- Extracts `failed_generation` from the error payload to give the model context about what went wrong

## Problem
When models (especially via Groq) generate tool calls with malformed JSON arguments (unescaped newlines, broken strings), the API returns a `tool_use_failed` error. Previously this was fatal — the entire completion would fail with `AI completion failed: received error while streaming`. This was especially bad for agentic workflows where the model needs to call `set_variable` with long-form content (e.g., LinkedIn posts) that often contains special characters.

## Fix
The retry loop now catches these errors, preserves any accumulated stream data, and asks the model to fix its JSON before trying again. This happens within the existing tool pass limit so it can't loop forever.

## Test plan
- [x] `go build ./internal/openai/...` compiles cleanly
- [ ] Deploy to production and verify workflow `8mqz-mcbvz` completes without tool call errors
- [ ] Verify retry logic kicks in on malformed JSON (check logs for `[karma] Tool call parsing error`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Improved recovery from AI parsing failures by automatically retrying with corrective input when parsing issues are detected.
  * Enhanced streaming reliability by preserving and returning partially received responses when a connection or stream error occurs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MelloB1989/karma/pull/7?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->